### PR TITLE
Add tree-sitter-vcl plugin with auto build

### DIFF
--- a/nvim/lua/plugins/lang.lua
+++ b/nvim/lua/plugins/lang.lua
@@ -1,5 +1,27 @@
 return {
   {
+    "ntsk/tree-sitter-vcl",
+    build = function(plugin)
+      local data = vim.fn.stdpath("data")
+      local parser_dir = data .. "/site/parser"
+      local queries_dir = data .. "/site/queries/vcl"
+      vim.fn.mkdir(parser_dir, "p")
+      vim.fn.mkdir(queries_dir, "p")
+      vim.fn.system({ "tree-sitter", "build", "-o", parser_dir .. "/vcl.so", plugin.dir })
+      vim.fn.system({ "cp", plugin.dir .. "/queries/highlights.scm", queries_dir .. "/" })
+    end,
+    ft = "vcl",
+    init = function()
+      vim.filetype.add({ extension = { vcl = "vcl" } })
+    end,
+    config = function()
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "vcl",
+        callback = function() vim.treesitter.start() end,
+      })
+    end,
+  },
+  {
     "fatih/vim-go",
     ft = "go",
     init = function()


### PR DESCRIPTION
Registers ntsk/tree-sitter-vcl with lazy.nvim. The `build` hook compiles the parser via `tree-sitter build` and copies highlight queries into `~/.local/share/nvim/site/`, so subsequent updates rebuild automatically.