### PR TITLE
Install tree-sitter CLI via Nix

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -31,6 +31,7 @@
     jq
     mise
     nerd-fonts.meslo-lg
+    tree-sitter
     usage
   ] ++ lib.optionals pkgs.stdenv.isLinux [
     xclip


### PR DESCRIPTION
Adds the tree-sitter CLI to `home.packages` so the lazy.nvim build hook for tree-sitter-vcl (and other grammar work) no longer relies on a Homebrew-managed `tree-sitter`.