### PR TITLE
Fix home.packages list to keep cross-platform packages on macOS

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -31,18 +31,17 @@
     jq
     mise
     nerd-fonts.meslo-lg
-    tree-sitter
-    usage
-  ] ++ lib.optionals pkgs.stdenv.isLinux [
-    xclip
-
     ripgrep
     tig
     tmux
+    tree-sitter
+    usage
     wget
     wezterm
     zsh-completions
     zsh-fzf-tab
+  ] ++ lib.optionals pkgs.stdenv.isLinux [
+    xclip
   ];
 
   programs.git = {


### PR DESCRIPTION
PR #113 inadvertently moved `ripgrep`, `tig`, `tmux`, `wget`, `wezterm`, `zsh-completions`, `zsh-fzf-tab` into the `lib.optionals pkgs.stdenv.isLinux [...]` block when adding `xclip`. As a result those packages were no longer installed on macOS.

This restores them to the cross-platform list and keeps only `xclip` under the Linux-only block.