### PR TITLE
Fetch android-cli impurely instead of locking it

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,41 +1,5 @@
 {
   "nodes": {
-    "android-cli-aarch64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-hQC1WSeZZGeu8/0Pe23YLrm/YjnN7FXZQ7jUsMWgbwI=",
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/darwin_arm64/android"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/darwin_arm64/android"
-      }
-    },
-    "android-cli-x86_64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-8a1TbX8Wr2FnF+8GFL6fiGeNjbA7SjpPtoLTGeUFgNo=",
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/darwin_x86_64/android"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/darwin_x86_64/android"
-      }
-    },
-    "android-cli-x86_64-linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-7PLQa0oON0cMyXNPwa/RYnFlmHI6lMfmBJv+tgZFU4k=",
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/linux_x86_64/android"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://dl.google.com/android/cli/latest/linux_x86_64/android"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -94,9 +58,6 @@
     },
     "root": {
       "inputs": {
-        "android-cli-aarch64-darwin": "android-cli-aarch64-darwin",
-        "android-cli-x86_64-darwin": "android-cli-x86_64-darwin",
-        "android-cli-x86_64-linux": "android-cli-x86_64-linux",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,35 +11,31 @@
       url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    # Android CLI is distributed as a single prebuilt binary per platform.
-    # Tracking the "latest" URLs as flake inputs lets `nix flake update`
-    # refresh them alongside everything else. No aarch64-linux binary exists.
-    android-cli-aarch64-darwin = {
-      url = "file+https://dl.google.com/android/cli/latest/darwin_arm64/android";
-      flake = false;
-    };
-    android-cli-x86_64-darwin = {
-      url = "file+https://dl.google.com/android/cli/latest/darwin_x86_64/android";
-      flake = false;
-    };
-    android-cli-x86_64-linux = {
-      url = "file+https://dl.google.com/android/cli/latest/linux_x86_64/android";
-      flake = false;
-    };
   };
 
   outputs = inputs@{ nixpkgs, home-manager, nix-darwin, ... }:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       currentUser = builtins.getEnv "USER";
+      # Android CLI ships as a single prebuilt binary per platform behind a
+      # mutable "latest" URL, so it cannot be meaningfully locked: the recorded
+      # hash stops matching once upstream overwrites the file. Fetch it impurely
+      # at eval time rather than as a flake input, so the lock file never claims
+      # a reproducibility it cannot provide. No aarch64-linux binary exists.
+      androidCliUrls = {
+        aarch64-darwin = "https://dl.google.com/android/cli/latest/darwin_arm64/android";
+        x86_64-darwin = "https://dl.google.com/android/cli/latest/darwin_x86_64/android";
+        x86_64-linux = "https://dl.google.com/android/cli/latest/linux_x86_64/android";
+      };
       androidCliFor = system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          src = inputs."android-cli-${system}" or null;
-        in if src == null
+          url = androidCliUrls.${system} or null;
+        in if url == null
            then null
-           else pkgs.callPackage ./pkgs/android-cli.nix { inherit src; };
+           else pkgs.callPackage ./pkgs/android-cli.nix {
+             src = builtins.fetchurl { inherit url; };
+           };
       mkHomeConfig = system:
         let
           pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
## What

Stop declaring the `android-cli-*` binaries as flake inputs. Fetch them with
`builtins.fetchurl` at eval time instead, and drop the now-unused entries from
`flake.lock`.

## Why

The android-cli binaries are served from a mutable `latest` URL whose contents
Google overwrites in place. As a flake input the recorded `narHash` stops
matching the live file the moment upstream changes, which broke the Flake Diff
job on the automated `Update flake.lock` PR (#125):

```
error: mismatch in field 'narHash' of input '...latest/linux_x86_64/android'
```

A `latest` URL cannot be meaningfully locked — the lock records a hash whose
content is no longer retrievable — so claiming it is `locked` is misleading.
Fetching impurely matches the actual behavior (always latest, not reproducible),
and removes the failure mode entirely: there is no lock entry to mismatch.

All build paths already run with `--impure` (switch.sh, ci.yml, flake-diff.yml),
so no caller changes are needed.

## Verification

- `nix eval` of the x86_64-linux and aarch64-darwin home configurations succeeds
- android-cli remains present in `home.packages`