### PR TITLE
Use nixpkgs tree-sitter-vcl grammar

### DIFF
--- a/nix/home/nvim/nvim.nix
+++ b/nix/home/nvim/nvim.nix
@@ -24,6 +24,7 @@ let
     { pkg = "c-sharp"; lang = "c_sharp"; }
     { pkg = "html"; lang = "html"; }
     { pkg = "css"; lang = "css"; }
+    { pkg = "vcl"; lang = "vcl"; }
   ];
 
   treesitterParsers = pkgs.runCommandLocal "nvim-treesitter-parsers" { } ''

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -36,7 +36,6 @@
   "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" },
   "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
-  "tree-sitter-vcl": { "branch": "main", "commit": "6c55ad2f48c4d8ec22ad69d9465855fa4d01c6a9" },
   "vim-better-whitespace": { "branch": "master", "commit": "de99b55a6fe8c96a69f9376f16b1d5d627a56e81" },
   "vim-closetag": { "branch": "master", "commit": "d0a562f8bdb107a50595aefe53b1a690460c3822" },
   "vim-go": { "branch": "master", "commit": "f4b4ba17035aebcd222df90375c1cbb1dc4d8c5b" },

--- a/nvim/lua/plugins/lang.lua
+++ b/nvim/lua/plugins/lang.lua
@@ -1,27 +1,5 @@
 return {
   {
-    "ntsk/tree-sitter-vcl",
-    build = function(plugin)
-      local data = vim.fn.stdpath("data")
-      local parser_dir = data .. "/site/parser"
-      local queries_dir = data .. "/site/queries/vcl"
-      vim.fn.mkdir(parser_dir, "p")
-      vim.fn.mkdir(queries_dir, "p")
-      vim.fn.system({ "tree-sitter", "build", "-o", parser_dir .. "/vcl.so", plugin.dir })
-      vim.fn.system({ "cp", plugin.dir .. "/queries/highlights.scm", queries_dir .. "/" })
-    end,
-    ft = "vcl",
-    init = function()
-      vim.filetype.add({ extension = { vcl = "vcl" } })
-    end,
-    config = function()
-      vim.api.nvim_create_autocmd("FileType", {
-        pattern = "vcl",
-        callback = function() vim.treesitter.start() end,
-      })
-    end,
-  },
-  {
     "fatih/vim-go",
     ft = "go",
     init = function()


### PR DESCRIPTION
tree-sitter-vcl が nixpkgs に入ったので、lazy.nvim でのローカルビルドをやめて Nix 管理のパーサーに切り替える。